### PR TITLE
Fix & add links in CS template

### DIFF
--- a/7._CS_Template.md
+++ b/7._CS_Template.md
@@ -2,9 +2,11 @@
 
 Community Specifications are recommended to be drafted in accordance with international best practices.  Doing so provides clarity, helps adoption, and also eases the transition of this specification to other standards body if so desired.  Accordingly, the recommended template below is based on ISO standard drafting conventions.
 
-To help you, this guide on writing standards was produced by the ISO/TMB and is available at https://www.iso.org/iso/how-to-write-standards.pdf.
+To help you, this guide on writing standards was produced by the ISO/TMB and is available at https://www.iso.org/files/live/sites/isoorg/files/developing_standards/docs/en/how-to-write-standards.pdf.
 
 A model manuscript of a draft International Standard (known as “The Rice Model”) is available at https://www.iso.org/iso/model_document-rice_model.pdf.
+
+The above documents and several other guides on effective standards drafting are available from ISO at https://www.iso.org/drafting-standards.html.
 
 In addition, we recommend using the key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" as described in RFC 2119 -  https://tools.ietf.org/html/rfc2119
 


### PR DESCRIPTION
Fix link to ISO "How to Write Standards" document in specification template. Add link to ISO page of resources for drafting standards.