### PR TITLE
Fix typo in foreword patent identification disclaimer

### DIFF
--- a/7._CS_Template.md
+++ b/7._CS_Template.md
@@ -48,7 +48,7 @@ Bibliography	1
 
 ## Foreword
 
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. No party shall not be held responsible for identifying any or all such patent rights.
+Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. No party shall be held responsible for identifying any or all such patent rights.
 
 Any trade name used in this document is information given for the convenience of users and does not constitute an endorsement.
 


### PR DESCRIPTION
The current language contains a statement with an incorrect double negative, "No party shall not be held responsible..." This commit fixes the typo.

Signed-off-by: Steve Winslow <steve@swinslow.net>