### PR TITLE
Update ..Getting Started.md

### DIFF
--- a/..Getting Started.md
+++ b/..Getting Started.md
@@ -54,7 +54,7 @@ Develop your specification in that repository.
 
 1. **Use for specifications, not code.**  Use the Community Specification License for specification development, not code.
 
-1. **Scope.** Draft the scope with care since it sets the outer bounds of the patent commitments participants make to the specification.  If you draft it too narrowly, you may limit the functionality of the specification, especially as the project progresses.  Draft it too broadly and it may provide a barrier to participation since participants may be unwilling to agree to potentially broad patent commitments.  For guidance on drafting an appropriate Scope, you may find [ISO's guidance (see page 5)](https://www.iso.org/files/live/sites/isoorg/files/archive/pdf/en/how-to-write-standards.pdf "ISO How To Write Standards Guide") helpful.
+1. **Scope.** Draft the scope with care since it sets the outer bounds of the patent commitments participants make to the specification.  If you draft it too narrowly, you may limit the functionality of the specification, especially as the project progresses.  Draft it too broadly and it may provide a barrier to participation since participants may be unwilling to agree to potentially broad patent commitments.  For guidance on drafting an appropriate Scope, you may find [ISO's guidance (see page 5)](https://www.iso.org/files/live/sites/isoorg/files/developing_standards/docs/en/how-to-write-standards.pdf "ISO How To Write Standards Guide") helpful.
 
 1.  **Specification format.**  Use the Community Specification Template to draft your specification.
 


### PR DESCRIPTION
Link to ISO guidance on wirting Scope in the "Best Practices" section was broken. 
I amended with a link that's the most up to date one I could find that was published in 2016. Not sure if there's another link that's more up to date?