### PR TITLE
Remove grammatical errror "not" in CS_Template.md

### DIFF
--- a/7._CS_Template.md
+++ b/7._CS_Template.md
@@ -8,12 +8,12 @@ A model manuscript of a draft International Standard (known as “The Rice Model
 
 In addition, we recommend using the key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" as described in RFC 2119 -  https://tools.ietf.org/html/rfc2119
 
- 
+
 ## Title
 ### Version _______
 ### Status (Pre-draft, Draft, Approved)
 
- 
+
 © _________________
 
 This specification is subject to the Community Specification License 1.0, available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
@@ -41,14 +41,14 @@ Introduction	i
 
 6	Clause title	1
 
-Annex A (informative)  
+Annex A (informative)
 
 Bibliography	1
 
 
 ## Foreword
 
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. No party shall not be held responsible for identifying any or all such patent rights.
+Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. No party shall be held responsible for identifying any or all such patent rights.
 
 Any trade name used in this document is information given for the convenience of users and does not constitute an endorsement.
 
@@ -67,7 +67,7 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The Contributors and Licensees express
 Introduction
 Type text.
 
- 
+
 ## Title (Introductory element — Main element — Part : Part title)
 1	Scope (mandatory)
 
@@ -133,7 +133,7 @@ term
 
 text of the definition
 
-4	Clause title 
+4	Clause title
 
 Type text.
 
@@ -143,9 +143,9 @@ Type text.
 
 Use subclauses if required e.g. 5.1 or 5.1.1. For example:
 
-5.1	Subclause 
+5.1	Subclause
 
-5.1.1	Subclause 
+5.1.1	Subclause
 
 6	Clause title
 

--- a/7._CS_Template.md
+++ b/7._CS_Template.md
@@ -8,12 +8,12 @@ A model manuscript of a draft International Standard (known as “The Rice Model
 
 In addition, we recommend using the key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" as described in RFC 2119 -  https://tools.ietf.org/html/rfc2119
 
-
+ 
 ## Title
 ### Version _______
 ### Status (Pre-draft, Draft, Approved)
 
-
+ 
 © _________________
 
 This specification is subject to the Community Specification License 1.0, available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
@@ -41,7 +41,7 @@ Introduction	i
 
 6	Clause title	1
 
-Annex A (informative)
+Annex A (informative)  
 
 Bibliography	1
 
@@ -67,7 +67,7 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The Contributors and Licensees express
 Introduction
 Type text.
 
-
+ 
 ## Title (Introductory element — Main element — Part : Part title)
 1	Scope (mandatory)
 
@@ -133,7 +133,7 @@ term
 
 text of the definition
 
-4	Clause title
+4	Clause title 
 
 Type text.
 
@@ -143,9 +143,9 @@ Type text.
 
 Use subclauses if required e.g. 5.1 or 5.1.1. For example:
 
-5.1	Subclause
+5.1	Subclause 
 
-5.1.1	Subclause
+5.1.1	Subclause 
 
 6	Clause title
 


### PR DESCRIPTION
Double negative.

- At Line 51, change from
  > No party shall **not** be held responsible

  to

  > No party shall be held responsible

The full paragraph is:

> Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. No party shall <s>not</s> be held responsible for identifying any or all such patent rights.

To fix #18 reported by @david-a-wheeler and fix #23 reported by @scouten-adobe (they are duplicated)