### PR TITLE
Update Readme (main branch) with SPDX License Identifier and badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ A second difference is that common open source software and specification licens
 
 The Community Specification has been developed via the [Joint Development Foundation](http://www.jointdevelopment.org), with inspiration from the [Open Web Foundation agreements](http://openwebfoundation.org) and the [Alliance for Open Media Patent License 1.0](http://aomedia.org/license/patent-license/).
 
-## SDPX License Identifier
+## SPDX License Identifier
 
 The SPDX License Identifier for the [Community Specification v1.0](https://spdx.org/licenses/Community-Spec-1.0.html) license is: `Community-Spec-1.0`.
 

--- a/Readme.md
+++ b/Readme.md
@@ -21,3 +21,19 @@ A second difference is that common open source software and specification licens
 ## Who developed the Community Specification
 
 The Community Specification has been developed via the [Joint Development Foundation](http://www.jointdevelopment.org), with inspiration from the [Open Web Foundation agreements](http://openwebfoundation.org) and the [Alliance for Open Media Patent License 1.0](http://aomedia.org/license/patent-license/).
+
+## SDPX License Identifier
+
+The SPDX License Identifier for the [Community Specification v1.0](https://spdx.org/licenses/Community-Spec-1.0.html) license is: `Community-Spec-1.0`.
+
+The SPDX short-form license statement (to be used in source files and documentation) for the license is:
+
+> **SPDX-License-Identifier: Community-Spec-1.0**
+
+A badge indicating the Community Spec v1.0 license can be added to a Markdown file with the following text:
+
+`![Community-Spec-1.0 license](https://img.shields.io/badge/License-Community--Spec--1.0-brightgreen)`
+
+This badge displays as:
+
+![Community-Spec-1.0 license](https://img.shields.io/badge/License-Community--Spec--1.0-brightgreen)

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Community Specification
 
-## What is the Community Specification For?
+## What is the Community Specification for?
 
 The Community Specification process is a repository-based approach for creating standards and specifications in version control systems, such as Git.
 


### PR DESCRIPTION
Added SPDX License Identifier and badge information to the Readme.md in main branch (which is acted as a landing page).

Based on content from #16, which is already merged for the development branch and available at https://github.com/CommunitySpecification/Community_Specification/blob/development/Readme.md
