### PR TITLE
README: Standardize caps + add missing "?"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 # Community Specification
 
-## What is the Community Specification For?
+## What is the Community Specification for?
 
 The Community Specification process is a repository-based approach for creating standards and specifications in version control systems, such as Git.
 
 ## What is the benefit?
 
-The Community Specification allows you to start a specification development effort as easily as an open source project.  The Community Specification incorporates the terms and processes required for standards and specification development, including legal terms, intellectual property issues, due process, and governance.  It also provides the mechanisms to allow your project to grow and scale.  For example, the Community Specification provides the basis to take your specification to other standards bodies, including international standards bodies, for formal standardization if your community desires to pursue those options.
+The Community Specification allows you to start a specification development effort as easily as an open source project. The Community Specification incorporates the terms and processes required for standards and specification development, including legal terms, intellectual property issues, due process, and governance. It also provides the mechanisms to allow your project to grow and scale. For example, the Community Specification provides the basis to take your specification to other standards bodies, including international standards bodies, for formal standardization if your community desires to pursue those options.
 
 ## How to get started?
 
@@ -18,6 +18,6 @@ Open source is collaboration around a specific codebase, while specifications pr
 
 A second difference is that common open source software and specification licenses tend to have different coverage scopes for intellectual property terms. Open source licenses generally grant terms scoped only to a contributor's contributions. Specification licenses, however, generally cover implementations of the entire specification, regardless of who made the actual contribution. Because the specification will often be developed with contributions from multiple organizations, the various contributing organizations will often want to review and approve the full specification before extending patent commitments to the final, combined result.
 
-## Who developed the Community Specification
+## Who developed the Community Specification?
 
 The Community Specification has been developed via the [Joint Development Foundation](http://www.jointdevelopment.org), with inspiration from the [Open Web Foundation agreements](http://openwebfoundation.org) and the [Alliance for Open Media Patent License 1.0](http://aomedia.org/license/patent-license/).


### PR DESCRIPTION
- Make one heading to use "sentence casing" like other headings ("For" -> "for")
- Add missing "?" at the end of one heading
- Standardized the whitespaces - replace 3 instances of two spaces between sentences with one space, make them similar to other sentences.
- Lowecase "Readme.md" to "readme.md" (follows convention in #32)